### PR TITLE
feat(gitops): sre-321 disabled masking of account id

### DIFF
--- a/.github/workflows/gitops.yaml
+++ b/.github/workflows/gitops.yaml
@@ -51,6 +51,7 @@ jobs:
       with:
         role-to-assume: arn:aws:iam::353817990488:role/github-actions
         aws-region: eu-west-2
+        mask-aws-account-id: false
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
gitops workflow to used managed runner